### PR TITLE
Adding default price to payload of products

### DIFF
--- a/konbini/core.py
+++ b/konbini/core.py
@@ -4,7 +4,7 @@ def get_products():
     return stripe.Product.list(expand=['data.default_price'], limit=100, active=True)['data']
 
 def get_product(id):
-    return stripe.Product.retrieve('prod_{}'.format(id))
+    return stripe.Product.retrieve('prod_{}'.format(id), expand=['default_price'])
 
 def get_customers(email):
     resp = stripe.Customer.list(email=email, limit=100)

--- a/konbini/core.py
+++ b/konbini/core.py
@@ -1,7 +1,7 @@
 import stripe
 
 def get_products():
-    return stripe.Product.list(limit=100, active=True)['data']
+    return stripe.Product.list(expand=['data.default_price'], limit=100, active=True)['data']
 
 def get_product(id):
     return stripe.Product.retrieve('prod_{}'.format(id))


### PR DESCRIPTION
Stripe returns an id for the default price of a product when querying a list of products, making it difficult to show the price when displaying the shop index. Adding "expand=['data.default_price'] puts the default price object inside of a product within the product list as well.